### PR TITLE
Layers: Make Background color themeable

### DIFF
--- a/res/values/colors.xml
+++ b/res/values/colors.xml
@@ -19,4 +19,5 @@
     <color name="theme_primary">#ff263238</color>
     <color name="theme_primary_dark">#ff21272b</color>
     <color name="theme_accent">#ff009688</color>
+    <color name="theme_background">@android:color/white</color>    
 </resources>

--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -8,5 +8,7 @@
       <item name="android:colorPrimaryDark">@color/theme_primary_dark</item>
       <!-- Used by controls, e.g. CheckBox, ProgressBar, etc. -->
       <item name="android:colorAccent">@color/theme_accent</item>
+      <!-- Background Color -->
+      <item name="android:windowBackground">@color/theme_background</item>      
     </style>    
 </resources>


### PR DESCRIPTION
Everytime I tried to do the same change to styles.xml with an overlay .apk, OpenDelta would FC. If I make the change to the source, then I can apply an overlay .apk with the theme_background color without a problem. So, here it is, a Layers themeable background.
